### PR TITLE
Keep Images descriptions in receivers.json

### DIFF
--- a/wikidotparser.py
+++ b/wikidotparser.py
@@ -72,10 +72,13 @@ def parse_photo_links(raw):
     links = []
     for link in re.finditer(photos_pattern, raw):
         if link.group('photo_url').startswith('/local--files'):
-            photos.append('{}/{}'.format(photos_base_url, link.group('photo_url')))
+            photos.append({
+                'href': '{}{}'.format(photos_base_url, link.group('photo_url')),
+                'rel': link.group('name')
+            })
         else:
             if re.match(image_url_pattern, link.group('photo_url')):
-                photos.append(link.group('photo_url'))
+                photos.append({'href': link.group('photo_url'), 'rel': link.group('name')})
             else:
                 links.append({'href': link.group('photo_url'), 'rel': link.group('name')})
     return photos, links


### PR DESCRIPTION
Remove also the duplicate slash in `’{}/{}’.format(photos_base_url,link.group('photo_url')`

`link.group('photo_url')` always start with a slash 😉 